### PR TITLE
Add ARAM data display in match details and adjust matchups logic

### DIFF
--- a/client/src/components/matches/MatchHeader.vue
+++ b/client/src/components/matches/MatchHeader.vue
@@ -34,8 +34,10 @@
         <span class="result-label">Game Result</span>
       </div>
       <div class="secondary-row">
-        <span class="role">{{ formatRole(match.role) }}</span>
-        <span class="separator">·</span>
+        <template v-if="match.role && match.role !== 'UNKNOWN'">
+          <span class="role">{{ formatRole(match.role) }}</span>
+          <span class="separator">·</span>
+        </template>
         <span class="queue">{{ match.queueType }}</span>
         <span class="separator">·</span>
         <span class="duration">{{ formatDuration(match.gameDurationSec) }}</span>

--- a/client/src/components/matches/MatchNarrative.vue
+++ b/client/src/components/matches/MatchNarrative.vue
@@ -18,7 +18,40 @@
         <span class="empty-text">No lane matchup data available</span>
       </div>
 
-      <!-- Lane matchups -->
+      <!-- ARAM Player List -->
+      <div v-else-if="narrativeData.isAram" class="aram-players">
+        <!-- Your Team -->
+        <div class="team-header ally">Your Team</div>
+        <div
+          v-for="participant in allyParticipants"
+          :key="participant.puuid"
+          class="aram-player-row"
+          :class="{ 'user-row': isUserChampion(participant) }"
+        >
+          <img :src="participant.championIconUrl" :alt="participant.championName" class="champion-icon" />
+          <span class="champion-name">
+            {{ participant.championName }}
+            <span v-if="isUserChampion(participant)" class="you-badge">YOU</span>
+          </span>
+          <span class="kda">{{ formatKda(participant) }}</span>
+          <span class="damage">{{ formatPercent(participant.damageShare) }} dmg</span>
+        </div>
+
+        <!-- Enemy Team -->
+        <div class="team-header enemy">Enemy Team</div>
+        <div
+          v-for="participant in enemyParticipants"
+          :key="participant.puuid"
+          class="aram-player-row enemy"
+        >
+          <img :src="participant.championIconUrl" :alt="participant.championName" class="champion-icon" />
+          <span class="champion-name">{{ participant.championName }}</span>
+          <span class="kda">{{ formatKda(participant) }}</span>
+          <span class="damage">{{ formatPercent(participant.damageShare) }} dmg</span>
+        </div>
+      </div>
+
+      <!-- Lane matchups (non-ARAM) -->
       <div v-else class="lane-matchups">
       <div
         v-for="matchup in narrativeData.laneMatchups"
@@ -76,7 +109,7 @@ import { ref, watch, computed } from 'vue'
 import { useAuthStore } from '../../stores/authStore'
 import { getMatchNarrative } from '../../services/authApi'
 import { trackLaneExpand } from '../../services/analyticsApi'
-import { formatRole, formatKdaFromParticipant as formatKda } from '@/utils/formatters'
+import { formatRole, formatKdaFromParticipant as formatKda, formatPercent } from '@/utils/formatters'
 import LaneMatchupDetails from './LaneMatchupDetails.vue'
 
 const props = defineProps({
@@ -143,6 +176,30 @@ function toggleExpand(role) {
 function isUserRole(role) {
   return narrativeData.value?.userRole === role
 }
+
+// Check if the participant is the user (for ARAM where roles are all UNKNOWN)
+function isUserChampion(participant) {
+  return participant?.puuid === puuid.value
+}
+
+// ARAM participants grouped by team, sorted by damage share
+const allyParticipants = computed(() => {
+  if (!narrativeData.value?.isAram || !narrativeData.value?.laneMatchups) {
+    return []
+  }
+  return narrativeData.value.laneMatchups
+    .map(m => m.allyParticipant)
+    .sort((a, b) => b.damageShare - a.damageShare)
+})
+
+const enemyParticipants = computed(() => {
+  if (!narrativeData.value?.isAram || !narrativeData.value?.laneMatchups) {
+    return []
+  }
+  return narrativeData.value.laneMatchups
+    .map(m => m.enemyParticipant)
+    .sort((a, b) => b.damageShare - a.damageShare)
+})
 
 // Community Dragon CDN for official League role icons
 const roleIconBaseUrl = 'https://raw.communitydragon.org/latest/plugins/rcp-fe-lol-clash/global/default/assets/images/position-selector/positions'
@@ -311,6 +368,79 @@ function getRoleIconUrl(role) {
 .lane-details {
   border-top: 1px solid var(--color-border);
   padding: var(--spacing-md);
+}
+
+/* ARAM Player List Styles */
+.aram-players {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.team-header {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: var(--spacing-xs) 0;
+  margin-top: var(--spacing-sm);
+}
+
+.team-header:first-child {
+  margin-top: 0;
+}
+
+.team-header.ally { color: var(--color-success); }
+.team-header.enemy { color: var(--color-error); }
+
+.aram-player-row {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+}
+
+.aram-player-row.enemy {
+  opacity: 0.8;
+}
+
+.aram-player-row.user-row {
+  background: linear-gradient(90deg, rgba(59, 130, 246, 0.08) 0%, var(--color-surface) 100%);
+  border-color: var(--color-primary);
+  border-left-color: var(--color-primary);
+}
+
+.aram-player-row .champion-icon {
+  width: 24px;
+  height: 24px;
+  border-radius: var(--radius-xs);
+}
+
+.aram-player-row .champion-name {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text);
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
+.aram-player-row .kda {
+  font-size: var(--font-size-xs);
+  color: var(--color-text);
+  min-width: 60px;
+  text-align: right;
+}
+
+.aram-player-row .damage {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+  min-width: 60px;
+  text-align: right;
 }
 </style>
 

--- a/client/src/components/matches/MatchRow.vue
+++ b/client/src/components/matches/MatchRow.vue
@@ -27,8 +27,10 @@
       <!-- Row 1: Champion + Context -->
       <div class="match-header">
         <span class="champion-name">{{ match.championName }}</span>
-        <span class="context-separator">·</span>
-        <span class="role-badge">{{ formatRole(match.role) }}</span>
+        <template v-if="match.role && match.role !== 'UNKNOWN'">
+          <span class="context-separator">·</span>
+          <span class="role-badge">{{ formatRole(match.role) }}</span>
+        </template>
         <span class="context-separator">·</span>
         <span class="queue-type">{{ match.queueType }}</span>
       </div>

--- a/server/Application/DTOs/Matches/MatchNarrativeDto.cs
+++ b/server/Application/DTOs/Matches/MatchNarrativeDto.cs
@@ -5,11 +5,13 @@ namespace RiotProxy.Application.DTOs.Matches;
 /// <summary>
 /// Response for the match narrative endpoint.
 /// Contains lane matchups for all 5 roles with detailed stats.
+/// For ARAM games, matchups are paired by damage share instead of role.
 /// </summary>
 public record MatchNarrativeResponse(
     [property: JsonPropertyName("matchId")] string MatchId,
     [property: JsonPropertyName("userRole")] string UserRole,
-    [property: JsonPropertyName("laneMatchups")] LaneMatchup[] LaneMatchups
+    [property: JsonPropertyName("laneMatchups")] LaneMatchup[] LaneMatchups,
+    [property: JsonPropertyName("isAram")] bool IsAram = false
 );
 
 /// <summary>

--- a/server/Application/Endpoints/Matches/MatchNarrativeEndpoint.cs
+++ b/server/Application/Endpoints/Matches/MatchNarrativeEndpoint.cs
@@ -86,10 +86,21 @@ public sealed class MatchNarrativeEndpoint : IEndpoint
                 var userTeamId = userParticipant.TeamId;
                 var userRole = userParticipant.Role ?? "UNKNOWN";
 
-                // Group participants by role and create lane matchups
-                var laneMatchups = CreateLaneMatchups(participants, userTeamId);
+                // Detect ARAM: all participants have role = "UNKNOWN"
+                var isAram = participants.All(p => p.Role == "UNKNOWN");
 
-                var response = new MatchNarrativeResponse(matchId, userRole, laneMatchups);
+                // Create matchups based on game type
+                LaneMatchup[] matchups;
+                if (isAram)
+                {
+                    matchups = CreateAramMatchups(participants, userTeamId);
+                }
+                else
+                {
+                    matchups = CreateLaneMatchups(participants, userTeamId);
+                }
+
+                var response = new MatchNarrativeResponse(matchId, userRole, matchups, isAram);
                 return Results.Ok(response);
             }
             catch (Exception ex)
@@ -126,6 +137,64 @@ public sealed class MatchNarrativeEndpoint : IEndpoint
         }
 
         return matchups.ToArray();
+    }
+
+    /// <summary>
+    /// Creates 5v5 matchups for ARAM games by pairing participants by damage share rank.
+    /// Highest damage dealer on ally team faces highest on enemy team, etc.
+    /// </summary>
+    private LaneMatchup[] CreateAramMatchups(IList<MatchupParticipantRaw> participants, int userTeamId)
+    {
+        // Sort each team by damage share (highest first)
+        var allies = participants
+            .Where(p => p.TeamId == userTeamId)
+            .OrderByDescending(p => p.DamageShare)
+            .ToList();
+
+        var enemies = participants
+            .Where(p => p.TeamId != userTeamId)
+            .OrderByDescending(p => p.DamageShare)
+            .ToList();
+
+        var matchups = new List<LaneMatchup>();
+
+        // Create 5 matchups by position
+        for (int i = 0; i < Math.Min(allies.Count, enemies.Count); i++)
+        {
+            var ally = allies[i];
+            var enemy = enemies[i];
+
+            // For ARAM, determine winner by overall performance (damage share comparison)
+            var laneWinner = DetermineAramWinner(ally, enemy);
+
+            matchups.Add(new LaneMatchup(
+                Role: $"ARAM_{i + 1}",  // ARAM_1, ARAM_2, etc.
+                AllyParticipant: ToMatchupParticipant(ally),
+                EnemyParticipant: ToMatchupParticipant(enemy),
+                LaneWinner: laneWinner
+            ));
+        }
+
+        return matchups.ToArray();
+    }
+
+    /// <summary>
+    /// Determines the winner in an ARAM matchup based on damage share and KDA.
+    /// </summary>
+    private static string DetermineAramWinner(MatchupParticipantRaw ally, MatchupParticipantRaw enemy)
+    {
+        // Compare damage share - higher damage share = better performance
+        var allyScore = (double)ally.DamageShare + ((double)ally.KillParticipation * 0.5);
+        var enemyScore = (double)enemy.DamageShare + ((double)enemy.KillParticipation * 0.5);
+
+        // Use 5% threshold for "winning"
+        var diff = allyScore - enemyScore;
+        return diff switch
+        {
+            >= 5 => "ally",
+            <= -5 => "enemy",
+            _ => "even"
+        };
     }
 
     private static string DetermineLaneWinner(int? allyGoldDiff, int? enemyGoldDiff)

--- a/server/Infrastructure/Database/Repositories/MatchesRepository.cs
+++ b/server/Infrastructure/Database/Repositories/MatchesRepository.cs
@@ -396,7 +396,7 @@ public class MatchesRepository : RepositoryBase, IMatchesRepository
         400 => "Normal Draft",
         430 => "Normal Blind",
         450 => "ARAM",
-        2400 => "ARAM: Mayhem",
+        1700 => "ARAM: Mayhem",
         _ => $"Queue {queueId}"
     };
 
@@ -413,7 +413,7 @@ public class MatchesRepository : RepositoryBase, IMatchesRepository
             "ranked_solo" => "AND m.queue_id = 420",
             "ranked_flex" => "AND m.queue_id = 440",
             "normal" => "AND m.queue_id IN (430, 400)",
-            "aram" => "AND m.queue_id IN (450, 2400)",  // 450 = ARAM, 2400 = ARAM: Mayhem
+            "aram" => "AND m.queue_id IN (450, 1700)",  // 450 = ARAM, 1700 = ARAM: Mayhem
             _ => ""  // all
         };
     }

--- a/server/Infrastructure/Database/Repositories/OverviewStatsRepository.cs
+++ b/server/Infrastructure/Database/Repositories/OverviewStatsRepository.cs
@@ -20,7 +20,7 @@ public class OverviewStatsRepository : RepositoryBase, IOverviewStatsRepository
         { 400, 3 },  // Normal Draft
         { 430, 3 },  // Normal Blind (same priority as Draft)
         { 450, 4 },  // ARAM
-        { 2400, 4 }, // ARAM: Mayhem (same priority as regular ARAM)
+        { 1700, 4 }, // ARAM: Mayhem (same priority as regular ARAM)
     };
 
     public OverviewStatsRepository(IDbConnectionFactory factory, ILogger<OverviewStatsRepository> logger) : base(factory)
@@ -226,7 +226,7 @@ public class OverviewStatsRepository : RepositoryBase, IOverviewStatsRepository
         400 => "Normal Draft",
         430 => "Normal Blind",
         450 => "ARAM",
-        2400 => "ARAM: Mayhem",
+        1700 => "ARAM: Mayhem",
         _ => $"Queue {queueId}"
     };
 }

--- a/server/Infrastructure/Database/Repositories/SoloStatsRepository.cs
+++ b/server/Infrastructure/Database/Repositories/SoloStatsRepository.cs
@@ -462,7 +462,7 @@ public class SoloStatsRepository : RepositoryBase, ISoloStatsRepository
             "ranked_solo" => "AND m.queue_id = 420",
             "ranked_flex" => "AND m.queue_id = 440",
             "normal" => "AND m.queue_id IN (430, 400)",
-            "aram" => "AND m.queue_id IN (450, 2400)",  // 450 = ARAM, 2400 = ARAM: Mayhem
+            "aram" => "AND m.queue_id IN (450, 1700)",  // 450 = ARAM, 1700 = ARAM: Mayhem
 	            _ => ""  // all
 	        };
 	    }


### PR DESCRIPTION
- Implement ARAM player list in MatchNarrative.vue with participant details.
- Update MatchHeader.vue to conditionally display roles for known participants.
- Modify MatchNarrativeDto to include isAram flag for ARAM games.
- Enhance MatchNarrativeEndpoint to create matchups based on ARAM logic.
- Fix queue ID for ARAM: Mayhem in MatchesRepository and OverviewStatsRepository.